### PR TITLE
disable ligatures in code

### DIFF
--- a/packages/fonts.tex
+++ b/packages/fonts.tex
@@ -28,7 +28,8 @@
     UprightFont=*-Regular,
     BoldFont=*-Bold,
     ItalicFont=*-Italic,
-    BoldItalicFont=*-BoldItalic
+    BoldItalicFont=*-BoldItalic,
+    Contextuals=AlternateOff
     ]
     
 \renewcommand{\familydefault}{\sfdefault}


### PR DESCRIPTION
Operators like `≤` and `≠` (instead of `<=` and `!=`) are not valid in C++ (AFAIK), but those are shown in the output PDF even if the C++ sources are correct. This is due to the hardcoded ligatures in the JetBrainsMono font.

IMHO this can be a source of confusion, so this patch disables that behavior. But note that the comments' `//` are now two characters wide, that may be a matter of taste... so reject this if you prefer it that way.

An alternative way to fix this is to use the `JetBrainsMonoNL` font variant instead.

BTW I got the info from here: https://github.com/tonsky/FiraCode/issues/388#issuecomment-671130160