### PR TITLE
Use std::lower_bound in notes for std::partition_point

### DIFF
--- a/chapters/03_algorithms_05_divide.tex
+++ b/chapters/03_algorithms_05_divide.tex
@@ -57,7 +57,7 @@ Because the lower bound returns the first element for which \texttt{elem >= valu
 \subsection{\texorpdfstring{\cpp{std::partition_point}}{\texttt{std::partition\_point}}}
 \index{\cpp{std::partition_point}}
 
-Despite the naming, \cpp{std:partition_point} works very similarly to \texttt{std::upper\-\_bound}, however instead of searching for a particular value, it searches using a predicate.
+Despite the naming, \cpp{std:partition_point} works very similarly to \texttt{std::lower\-\_bound}, however instead of searching for a particular value, it searches using a predicate.
 
 \cppversions{\texttt{partition\_point}}{\CC11}{\CC20}{N/A}{\CC20}
 \constraints{\texttt{forward\_range}}{}{N/A}{\texttt{unary\_predicate}}


### PR DESCRIPTION
Changed upper_bound to lower_bound since lower_bound is actually similar to std::partition_point rather than upper_bound.

[From notes about std::partition point on cppreference.com](https://en.cppreference.com/w/cpp/algorithm/partition_point#:~:text=Notes,.)
```
This algorithm is a more general form of std::lower_bound, which can be expressed in terms of std::partition_point with the predicate [&](auto const& e) { return e < value; });
```
